### PR TITLE
feat(include-comments): Include comments in d-ts files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "moduleResolution": "node",
         "rootDir": ".",
         "sourceMap": true,
+        "removeComments": false,
         "declaration": true,
         "forceConsistentCasingInFileNames": true,
         "allowJs": false


### PR DESCRIPTION
This way, jsdoc is preserved.
