### PR TITLE
feat(unincluded-files): Add `include` boolean

### DIFF
--- a/core.ts
+++ b/core.ts
@@ -4,3 +4,4 @@ export {default as InputFile} from './src/core/InputFile';
 export {default as Position} from './src/core/Position';
 export {default as Location} from './src/core/Location';
 export {default as Range} from './src/core/Range';
+export {default as FilePatternDescriptor} from './src/core/FilePatternDescriptor';

--- a/core.ts
+++ b/core.ts
@@ -4,4 +4,4 @@ export {default as InputFile} from './src/core/InputFile';
 export {default as Position} from './src/core/Position';
 export {default as Location} from './src/core/Location';
 export {default as Range} from './src/core/Range';
-export {default as FilePatternDescriptor} from './src/core/FilePatternDescriptor';
+export {default as InputFileDescriptor} from './src/core/InputFileDescriptor';

--- a/src/core/FilePatternDescriptor.ts
+++ b/src/core/FilePatternDescriptor.ts
@@ -1,0 +1,7 @@
+
+interface FilePatternDescriptor {
+  pattern: string;
+  included: boolean;
+}
+
+export default FilePatternDescriptor;

--- a/src/core/FilePatternDescriptor.ts
+++ b/src/core/FilePatternDescriptor.ts
@@ -1,7 +1,0 @@
-
-interface FilePatternDescriptor {
-  pattern: string;
-  included: boolean;
-}
-
-export default FilePatternDescriptor;

--- a/src/core/InputFile.ts
+++ b/src/core/InputFile.ts
@@ -1,7 +1,7 @@
 
 interface InputFile{
   path: string;
-  shouldMutate: boolean;
+  mutated: boolean;
   included: boolean;
 }
 

--- a/src/core/InputFile.ts
+++ b/src/core/InputFile.ts
@@ -2,6 +2,7 @@
 interface InputFile{
   path: string;
   shouldMutate: boolean;
+  included: boolean;
 }
 
 export default InputFile;

--- a/src/core/InputFileDescriptor.ts
+++ b/src/core/InputFileDescriptor.ts
@@ -1,0 +1,8 @@
+
+interface InputFileDescriptor {
+  pattern: string;
+  included?: boolean;
+  mutated?: boolean;
+}
+
+export default InputFileDescriptor;

--- a/src/core/StrykerOptions.ts
+++ b/src/core/StrykerOptions.ts
@@ -1,4 +1,4 @@
-import FilePatternDescriptor from './FilePatternDescriptor';
+import InputFileDescriptor from './InputFileDescriptor';
 
 interface StrykerOptions {
   // this ensures that custom config for for example 'karma' can be added under the 'karma' key
@@ -12,11 +12,12 @@ interface StrykerOptions {
    * * { pattern: 'pattern', included: true } : 
    *    * The `pattern` property is mandatory and contains the globbing expression used for selecting the files
    *    * The `included` property is optional and determines whether or not this file should be loaded initially by the test-runner (default: true)
+   *    * The `mutated` property is optional and determines whether or not this file should be targeted for mutations (default: false)
    * 
    * @example
    *     files: ['test/helpers/**\/*.js', 'test/unit/**\/*.js', { pattern: 'src/**\/*.js', included: false }],
    */
-  files?: (string | FilePatternDescriptor)[];
+  files?: Array<string | InputFileDescriptor>;
 
   /**
    * A list of globbing expression used for selecting the files that should be mutated.

--- a/src/core/StrykerOptions.ts
+++ b/src/core/StrykerOptions.ts
@@ -1,24 +1,33 @@
-'use strict';
+import FilePatternDescriptor from './FilePatternDescriptor';
 
 interface StrykerOptions {
   // this ensures that custom config for for example 'karma' can be added under the 'karma' key
   [customConfig: string]: any;
-  
+
   /**
-   * A list of globbing expression used for selecting all files needed to run the tests. These include library files, test files and files to mutate, but should NOT include test framework files (for example jasmine).
+   * The files array determines which files are in scope for mutation testing.
+   * These include library files, test files and files to mutate, but should NOT include test framework files (for example jasmine).
+   * Each element can be either a string or an object with 2 properties
+   * * `string`: A globbing expression used for selecting the files needed to run the tests.
+   * * { pattern: 'pattern', included: true } : 
+   *    * The `pattern` property is mandatory and contains the globbing expression used for selecting the files
+   *    * The `included` property is optional and determines whether or not this file should be loaded initially by the test-runner (default: true)
+   * 
+   * @example
+   *     files: ['test/helpers/**\/*.js', 'test/unit/**\/*.js', { pattern: 'src/**\/*.js', included: false }],
    */
-  files?: string[];
-  
+  files?: (string | FilePatternDescriptor)[];
+
   /**
    * A list of globbing expression used for selecting the files that should be mutated.
    */
   mutate?: string[];
-  
+
   /**
    * A location to a config file. That file should export a function which accepts a "config" object which it uses to configure stryker
    */
   configFile?: string;
-  
+
   /**
    * The name of the test framework to use
    */
@@ -33,34 +42,34 @@ interface StrykerOptions {
    * The name of the test runner to use (default is the same name as the testFramework)
    */
   testRunner?: string;
-  
+
   /**
    * The name (or names) of the reporter to use
    * Possible values: 'clear-text', 'progress'. 
    * Load more plugins to be able to use more plugins 
    */
   reporter?: string | string[];
-  
+
   /**
    * The log4js loglevel. Possible values: fatal, error, warn, info, debug, trace, all and off. Default is "info"
    */
   logLevel?: string;
-  
+
   /**
    * Amount of additional time, in milliseconds, the mutation test is allowed to run
    */
   timeoutMs?: number;
-  
+
   /**
    * The factor is applied on top of the other timeouts when during mutation testing
    */
   timeoutFactor?: number;
- 
+
   /**
    * A list of plugins. These plugins will be imported ('required') by Stryker upon loading.
    */
   plugins?: string[];
-  
+
   /**
    * The starting port to used for test frameworks that need to run a server (for example karma). 
    * If more test runners will run simultaniously, subsequent port numbers will be used (n+1, n+2, etc.)

--- a/test/integration/install-module/install-module.ts
+++ b/test/integration/install-module/install-module.ts
@@ -36,7 +36,7 @@ describe('we have a module using stryker', function () {
         executor.exec('npm run tsc', {}, (errors) => done(errors));
       });
 
-      arrangeActAndAssertModule('core', ['files', 'some', 'file']);
+      arrangeActAndAssertModule('core', ['files', 'some', 'file', 'pattern']);
       arrangeActAndAssertModule('config', ['plugins: [ \'stryker-*\' ]', 'port: 9234']);
       arrangeActAndAssertModule('test_selector', ['selector-1']);
       arrangeActAndAssertModule('mutant', ['nodeID: 3', 'type: \'node\'']);

--- a/testResources/module/useCore.ts
+++ b/testResources/module/useCore.ts
@@ -1,8 +1,8 @@
-import {StrykerOptions, Factory, InputFile, Position, Location, Range} from 'stryker-api/core';
+import {StrykerOptions, Factory, InputFile, FilePatternDescriptor, Position, Location, Range} from 'stryker-api/core';
 
 let options: StrykerOptions = {};
 let optionsAllArgs: StrykerOptions = {
-  files: ['some', 'file'],
+  files: ['some', 'file', { included: false, pattern: 'some pattern' }],
   mutate: ['some'],
   configFile: 'string',
   testFramework: 'string',
@@ -17,10 +17,12 @@ let optionsAllArgs: StrykerOptions = {
 
 let inputFile: InputFile = {
   path: 'string',
-  shouldMutate: true
+  shouldMutate: true,
+  included: true
 }
 
 let range: Range = [1, 2];
+let filePatternDescriptor: FilePatternDescriptor = { included: true, pattern: '/files/**/*.js' };
 let position: Position = { column: 2, line: 2 };
 let location: Location = { start: position, end: position };
 

--- a/testResources/module/useCore.ts
+++ b/testResources/module/useCore.ts
@@ -1,8 +1,8 @@
-import {StrykerOptions, Factory, InputFile, FilePatternDescriptor, Position, Location, Range} from 'stryker-api/core';
+import {StrykerOptions, Factory, InputFile, InputFileDescriptor, Position, Location, Range} from 'stryker-api/core';
 
 let options: StrykerOptions = {};
 let optionsAllArgs: StrykerOptions = {
-  files: ['some', 'file', { included: false, pattern: 'some pattern' }],
+  files: ['some', { pattern: 'file' }, { included: false, mutated: true, pattern: 'some pattern' }],
   mutate: ['some'],
   configFile: 'string',
   testFramework: 'string',
@@ -17,13 +17,13 @@ let optionsAllArgs: StrykerOptions = {
 
 let inputFile: InputFile = {
   path: 'string',
-  shouldMutate: true,
+  mutated: true,
   included: true
 }
 
 let range: Range = [1, 2];
-let filePatternDescriptor: FilePatternDescriptor = { included: true, pattern: '/files/**/*.js' };
+let filePatternDescriptor: InputFileDescriptor = { included: true, mutated: false, pattern: '/files/**/*.js' };
 let position: Position = { column: 2, line: 2 };
 let location: Location = { start: position, end: position };
 
-console.log(range, position, location, inputFile, optionsAllArgs, options);
+console.log(range, position, location, inputFile, optionsAllArgs, options, filePatternDescriptor);

--- a/testResources/module/useTestRunner.ts
+++ b/testResources/module/useTestRunner.ts
@@ -9,7 +9,7 @@ class MyTestRunner implements TestRunner {
 }
 
 let runnerOptions: RunnerOptions = {
-  files: [{ path: 'some', shouldMutate: true }, { path: 'files', shouldMutate: false }],
+  files: [{ path: 'some', shouldMutate: true, included: false }, { path: 'files', shouldMutate: false, included: true }],
   port: 1,
   strykerOptions: null
 }

--- a/testResources/module/useTestRunner.ts
+++ b/testResources/module/useTestRunner.ts
@@ -9,7 +9,7 @@ class MyTestRunner implements TestRunner {
 }
 
 let runnerOptions: RunnerOptions = {
-  files: [{ path: 'some', shouldMutate: true, included: false }, { path: 'files', shouldMutate: false, included: true }],
+  files: [{ path: 'some', mutated: true, included: false }, { path: 'files', mutated: false, included: true }],
   port: 1,
   strykerOptions: null
 }


### PR DESCRIPTION
Add the possibility to specify which files are in scope of Stryker, but should be excluded from the test runner.

Excluded from the test runner means for karma: included: false and for mocha: clear from cache, but don't include as test file.

See https://github.com/stryker-mutator/stryker/issues/115
