### PR TITLE
feat(mutant-status): Add `Error` to `MutantStatus`

### DIFF
--- a/src/report/MutantStatus.ts
+++ b/src/report/MutantStatus.ts
@@ -18,7 +18,12 @@ enum MutantStatus {
   /**
    * The status of a timed out mutant.
    */
-  TimedOut
+  TimedOut,
+
+  /**
+   * The status of a mutant of which the tests resulted in an Error
+   */
+  Error
 }
 
 export default MutantStatus;

--- a/test/integration/install-module/install-module.ts
+++ b/test/integration/install-module/install-module.ts
@@ -40,7 +40,7 @@ describe('we have a module using stryker', function () {
       arrangeActAndAssertModule('config', ['plugins: [ \'stryker-*\' ]', 'port: 9234']);
       arrangeActAndAssertModule('test_framework', ['framework-1']);
       arrangeActAndAssertModule('mutant', ['nodeID: 3', 'type: \'Literal\'']);
-      arrangeActAndAssertModule('report', ['empty', 'all', 'status: 3', 'originalLines: \'string\'']);
+      arrangeActAndAssertModule('report', ['empty', 'all', 'status: 3', 'originalLines: \'string\'', 'Mutant status error: Error']);
       arrangeActAndAssertModule('test_runner', ['MyTestRunner']);
 
     });

--- a/testResources/module/useReport.ts
+++ b/testResources/module/useReport.ts
@@ -42,3 +42,4 @@ let result: MutantResult = {
 };
 allReporter.onMutantTested(result);
 console.log(result);
+console.log(`Mutant status error: ${MutantStatus[MutantStatus.Error]}`);


### PR DESCRIPTION
Add `Error` to `MutantStatus` in order to accommodate for test runs which resulted in an `Error` during mutation testing.

At first: we decided to use `MutantStatus.Killed` for test runs resulting in an error, but this is not correct. An error might be due to the fact that we mutated something, but it might also indicate a deeper problem with your test suite.

It is more correct, and more save, to introduce this new status for mutants.