### PR TITLE
fix(coverage): Allow baseline coverage per test

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -6,5 +6,8 @@
     "test": [
         "test/**",
         "testResources/**"
+     ],
+     "ignore": [
+         "src/report/MatchedMutant.ts"
      ]
 }

--- a/src/test_runner/Coverage.ts
+++ b/src/test_runner/Coverage.ts
@@ -3,6 +3,21 @@ import {Location} from '../../core';
 /**
  * Represents a collection of code coverage results per test run.
  */
+export interface CoveragePerTestResult {
+  /**
+   * The baseline coverage which is true for each test run. 
+   * This baseline should be taken when all files all loaded, but before tests are ran. 
+   */
+  baseline: CoverageCollection;
+  /**
+   * The deviations with respect to the baseline per test.  
+   */
+  deviations: CoverageCollectionPerTest;
+}
+
+/**
+ * Represents a collection of code coverage results per test run.
+ */
 export interface CoverageCollectionPerTest {
   [testId: number]: CoverageCollection;
 }

--- a/src/test_runner/RunResult.ts
+++ b/src/test_runner/RunResult.ts
@@ -1,9 +1,9 @@
 import TestResult from './TestResult';
 import RunStatus from './RunStatus';
-import { CoverageCollection, CoverageCollectionPerTest } from './Coverage';
+import { CoverageCollection, CoveragePerTestResult } from './Coverage';
 
 /**
- * Represents the result of a testrun.
+ * Represents the result of a test run.
  */
 interface RunResult {
   /**
@@ -24,7 +24,7 @@ interface RunResult {
   /**
    * Optional: the code coverage result of the run.
    */
-  coverage?: CoverageCollection | CoverageCollectionPerTest;
+  coverage?: CoverageCollection | CoveragePerTestResult;
 }
 
 export default RunResult;


### PR DESCRIPTION
Allow coverage result per test to use a `baseline` coverage (coverage which is true for each test) and deviations on that baseline per test. That way the test amount of coverage data (in bytes) can be significantly reduced.